### PR TITLE
ESM support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "fire-extra-functionality",
       "version": "1.3.3",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
@@ -17,6 +16,7 @@
         "@typescript-eslint/eslint-plugin": "^4.30.0",
         "@typescript-eslint/parser": "^4.30.0",
         "chai": "^4.3.4",
+        "cross-env": "^7.0.3",
         "eslint": "^7.32.0",
         "jsdom": "^17.0.0",
         "mocha": "^9.1.1",
@@ -1140,6 +1140,24 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -5137,6 +5155,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "jsdom": "^17.0.0",
         "mocha": "^9.1.1",
         "node-fetch": "^3.0.0",
+        "resolve-typescript-plugin": "^1.1.0",
         "ts-loader": "^9.2.5",
         "ts-node": "^10.2.1",
         "typescript": "^4.4.2",
@@ -3210,6 +3211,27 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/resolve-typescript-plugin": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-typescript-plugin/-/resolve-typescript-plugin-1.1.0.tgz",
+      "integrity": "sha512-jsj27SwAGynpAaspMB4gNyRQJA2YrhDrpU8yLY6yM9MglnBSS06dKGZR3RdRr0Y2+fO/kkl3cAsaoody8x2fyA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "2.3.0"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/resolve-typescript-plugin/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "dev": true
     },
     "node_modules/reusify": {
       "version": "1.0.4",
@@ -6677,6 +6699,23 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
+    },
+    "resolve-typescript-plugin": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-typescript-plugin/-/resolve-typescript-plugin-1.1.0.tgz",
+      "integrity": "sha512-jsj27SwAGynpAaspMB4gNyRQJA2YrhDrpU8yLY6yM9MglnBSS06dKGZR3RdRr0Y2+fO/kkl3cAsaoody8x2fyA==",
+      "dev": true,
+      "requires": {
+        "tslib": "2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+          "dev": true
+        }
+      }
     },
     "reusify": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.3",
   "description": "Adds some more features to the FIRE userscript",
   "scripts": {
-    "build": "npm run lint && webpack ./src/*.ts",
+    "build": "npm run lint && webpack",
     "lint": "eslint src --fix --ext .ts",
     "test": "cross-env TS_NODE_PROJECT=test/tsconfig.json node --loader ts-node/esm node_modules/mocha/lib/cli/cli test/**/*.spec.ts"
   },
@@ -32,6 +32,7 @@
     "jsdom": "^17.0.0",
     "mocha": "^9.1.1",
     "node-fetch": "^3.0.0",
+    "resolve-typescript-plugin": "^1.1.0",
     "ts-loader": "^9.2.5",
     "ts-node": "^10.2.1",
     "typescript": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "npm run lint && webpack ./src/*.ts",
     "lint": "eslint src --fix --ext .ts",
-    "test": "mocha -r ts-node/register test/**/*.spec.ts"
+    "test": "node --loader ts-node/esm node_modules/mocha/lib/cli/cli test/**/*.spec.ts"
   },
   "repository": {
     "type": "git",
@@ -36,5 +36,6 @@
     "typescript": "^4.4.2",
     "webpack": "^5.52.0",
     "webpack-cli": "^4.8.0"
-  }
+  },
+  "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "npm run lint && webpack ./src/*.ts",
     "lint": "eslint src --fix --ext .ts",
-    "test": "node --loader ts-node/esm node_modules/mocha/lib/cli/cli test/**/*.spec.ts"
+    "test": "cross-env TS_NODE_PROJECT=test/tsconfig.json node --loader ts-node/esm node_modules/mocha/lib/cli/cli test/**/*.spec.ts"
   },
   "repository": {
     "type": "git",
@@ -27,6 +27,7 @@
     "@typescript-eslint/eslint-plugin": "^4.30.0",
     "@typescript-eslint/parser": "^4.30.0",
     "chai": "^4.3.4",
+    "cross-env": "^7.0.3",
     "eslint": "^7.32.0",
     "jsdom": "^17.0.0",
     "mocha": "^9.1.1",

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -1,6 +1,6 @@
-import { Toastr } from './index';
-import * as github from './github';
-import { Domains } from './domain_stats';
+import { Toastr } from './index.js';
+import * as github from './github.js';
+import { Domains } from './domain_stats.js';
 import fetch from 'node-fetch';
 
 declare const toastr: Toastr;

--- a/src/domain_stats.ts
+++ b/src/domain_stats.ts
@@ -1,6 +1,6 @@
-import * as metasmoke from './metasmoke';
-import * as github from './github';
-import { Toastr, indexHelpers } from './index';
+import * as metasmoke from './metasmoke.js';
+import * as github from './github.js';
+import { Toastr, indexHelpers } from './index.js';
 import fetch from 'node-fetch';
 
 declare const toastr: Toastr;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-import * as github from './github';
-import * as metasmoke from './metasmoke';
-import * as chat from './chat';
-import * as stackexchange from './stackexchange';
-import { Domains } from './domain_stats';
+import * as github from './github.js';
+import * as metasmoke from './metasmoke.js';
+import * as chat from './chat.js';
+import * as stackexchange from './stackexchange.js';
+import { Domains } from './domain_stats.js';
 
 export interface Toastr {
     success(message: string): void;

--- a/test/chat.spec.ts
+++ b/test/chat.spec.ts
@@ -1,10 +1,11 @@
 /* eslint-disable no-unused-expressions */
 import { expect } from 'chai';
-import { JSDOM } from 'jsdom';
-import { newChatEventOccurred } from '../src/chat';
-import { Domains } from '../src/domain_stats';
-import { indexHelpers } from '../src/index';
+import jsdom from 'jsdom';
 import fetch from 'node-fetch';
+import { newChatEventOccurred } from '../src/chat.js';
+import { Domains } from '../src/domain_stats.js';
+import { indexHelpers } from '../src/index.js';
+const { JSDOM } = jsdom;
 
 type ChatMessageActions = 'watch' | 'unwatch' | 'blacklist' | 'unblacklist';
 function getRandomChatMessage(originalChatMessage: string, actionType: ChatMessageActions, escapedDomain: string): string {
@@ -12,7 +13,10 @@ function getRandomChatMessage(originalChatMessage: string, actionType: ChatMessa
     return originalChatMessage.replace('Auto watch', `Auto ${actionType}`).replace('linuxbuz\\.com', escapedDomain);
 }
 
-describe('chat helpers', () => {
+describe('chat helpers', function () {
+
+    this.timeout(5e3); // before hook can timeout
+
     before(async () => await Domains.fetchAllDomainInformation());
     it('should update watches or blacklists based on the content of a chat message', async () => {
         const chatMessageCall = await fetch('https://chat.stackexchange.com/message/58329215');

--- a/test/github.spec.ts
+++ b/test/github.spec.ts
@@ -1,8 +1,9 @@
 /* eslint-disable no-tabs, no-unused-expressions */
 import { expect } from 'chai';
-import { indexHelpers } from '../src/index';
-import * as github from '../src/github';
-import { JSDOM } from 'jsdom';
+import { indexHelpers } from '../src/index.js';
+import * as github from '../src/github.js';
+import jsdom from "jsdom";
+const { JSDOM } = jsdom;
 
 const watchedKeywordsExample = String.raw`1494929269	tripleee	thewellnesscorner\.com
 1494929399	tripleee	optisolbusiness\.com

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 import { expect } from 'chai';
-import { Domains } from '../src/domain_stats';
-import { indexHelpers } from '../src/index';
+import { Domains } from '../src/domain_stats.js';
+import { indexHelpers } from '../src/index.js';
 
 describe('index helpers', () => {
     before(async () => await Domains.fetchAllDomainInformation());

--- a/test/metasmoke.spec.ts
+++ b/test/metasmoke.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-expressions */
 import { expect } from 'chai';
-import { getAllDomainsFromPost } from '../src/metasmoke';
+import { getAllDomainsFromPost } from '../src/metasmoke.js';
 
 global.window = {} as Window & typeof globalThis;
 

--- a/test/stackexchange.spec.ts
+++ b/test/stackexchange.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-expressions */
 import { expect } from 'chai';
-import { getShortenedResultCount } from '../src/stackexchange';
+import { getShortenedResultCount } from '../src/stackexchange.js';
 
 describe('stackexchange helpers', () => {
     it('should correctly get the correct shortened result count', () => {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "module": "esnext",
+        "esModuleInterop": true
+    },
+    "include": ["."],
+    "exclude": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,16 @@
 {
-  "compilerOptions": {
-    "strict": true,
-    "lib": ["DOM", "DOM.iterable", "es2020"],
-    "target": "es2019",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "noUnusedParameters": true,
-    "noUnusedLocals": true,
-    "noErrorTruncation": true,
-    "downlevelIteration": true,
-    "removeComments": true,
-    "outDir": "dist"
-  }
+    "compilerOptions": {
+        "strict": true,
+        "lib": ["DOM", "DOM.iterable", "es2020"],
+        "target": "es2019",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "noUnusedParameters": true,
+        "noUnusedLocals": true,
+        "noErrorTruncation": true,
+        "downlevelIteration": true,
+        "removeComments": true,
+        "outDir": "dist"
+    },
+    "include": ["src"]
 }

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -1,6 +1,7 @@
 const path = require('path');
 const webpack = require('webpack'); // for the banner plugin
 const userscriptInfo = require('./package.json');
+const { default: ResolveTypeScriptPlugin } = require("resolve-typescript-plugin");
 
 module.exports = {
     entry: './src/index.ts',
@@ -56,5 +57,10 @@ module.exports = {
                 loader: 'ts-loader'
             }
         ]
+    },
+    // until WebPack supports .js imports:
+    resolve: {
+        fullySpecified: true,
+        plugins: [new ResolveTypeScriptPlugin()]
     }
-}
+};


### PR DESCRIPTION
This PR updates the package to support ESM + TypeScript testing setup with Mocha.

There is a lot to unpack, but I tried to make the change as non-invasive as possible + annotate every commit with what exactly leads to the issue being solved.

Ta Da!

Regarding the change to `node --loader ts-node/esm` see the [Reference issue](https://github.com/TypeStrong/ts-node/issues/1007) (specifically, [this comment](https://github.com/TypeStrong/ts-node/issues/1007#issuecomment-633308908))