### PR TITLE
Remove reliance on manually-added fire-popup-appeared event, listening instead to natively-fired fire-popup-open

### DIFF
--- a/dist/fire_extra.user.js
+++ b/dist/fire_extra.user.js
@@ -16,9 +16,6 @@
 // @supportURL  https://github.com/userscripters/fire-extra-functionality/issues
 // ==/UserScript==
 /* globals fire, toastr, CHAT */
-// NOTE: after installing this script, you need to modify FIRE. Add this line:
-//     window.dispatchEvent(new CustomEvent('fire-popup-appeared'));
-// before L1253 - hideReportImages(). This will fire an event when the FIRE popup opens which this userscript listens to.
 // The script only runs on Charcoal HQ (11540) for now.
 /******/ (() => { // webpackBootstrap
 /******/ 	"use strict";
@@ -167,7 +164,7 @@ void (async function () {
         });
         chat.newChatEventOccurred(eventToPass);
     });
-    window.addEventListener('fire-popup-appeared', addHtmlToFirePopup);
+    window.addEventListener('fire-popup-open', addHtmlToFirePopup);
     GM_addStyle(`
 .fire-extra-domains-list {
   padding: 5px !important;


### PR DESCRIPTION
Since [this commit](https://github.com/Charcoal-SE/userscripts/commit/02b5b33d10e662b857fbcb81461b9796e355c5ba) in FIRE's script,  we no longer need to reply upon the user adding a specific event in a specific spot. We can instead listen for the `fire-popup-open` event that's fired from FIRE.

What this PR does is exactly that. It removes the problem where people [won't be able to receive updates to FIRE automatically](https://chat.stackexchange.com/transcript/message/60839544#60839544) because they've manually edited FIRE's code, and allows users to simply install this script and go.

The change that added these events in FIRE's code was released via FIRE version 1.4.0, [back in November](https://github.com/Charcoal-SE/userscripts/commit/5e603e8a85a4c6f68b84f096463cbdb1367440ae).

After testing, this appears to function the same as when utilizing the previous method (hooking into the manually-added `fire-popup-appeared` event).

🆑
change: Event listener for adding HTML now listens for fire-popup-open instead of fire-popup-appeared
remove: Comment instructions for first-time users
/🆑