### PR TITLE
Refine the escapedDomain string for the watch and blacklist tooltips to use more accurate regex (accounts for blogspot domains and domains with more than one period (.))

### DIFF
--- a/dist/fire_extra.user.js
+++ b/dist/fire_extra.user.js
@@ -49,7 +49,7 @@ function updateDomainInformation(domainName) {
         return;
     const isWatched = exports.indexHelpers.isCaught(domain_stats_js_1.Domains.watchedWebsitesRegexes, domainName);
     const isBlacklisted = exports.indexHelpers.isCaught(domain_stats_js_1.Domains.blacklistedWebsitesRegexes, domainName);
-    const escapedDomain = domainName.replace(/\./, '\\.');
+    const escapedDomain = domainName.replace(/blogspot\..*$/g, 'blogspot').replace(/\./g, '\\.');
     const watch = {
         human: 'watched: ' + (isWatched ? 'yes' : 'no'),
         tooltip: isWatched || isBlacklisted ? 'domain already watched' : `!!/watch- ${escapedDomain}`,


### PR DESCRIPTION
PR #40 was awesome. It made sure that the !!/watch button will strip the TLD when you push it when watching a blogspot domain. However, the tooltip doesn't reflect that, as it uses the older version of the regex replacement. It also uses a regex replacement that only replaces one period with an escaped version ( turns . to \\. once)

The proposed changes copy the existing replacements in the `addHtmlToFirePopup` to the `updateDomainInformation` function, to ensure that the user recognizes that "\\.com" will be omitted when performing a watch against a blogspot domain, and also to ensure that domains with multiple periods (example: google.co.uk) will properly escape those periods.

I suspect your branch already has changes that account for this (or invalidate them entirely) but it's not a bad bandaid PR for the time being.